### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @primait/domain-sre
+* @primait/developer-experience @primait/domain-sre

--- a/backstage-catalog.yaml
+++ b/backstage-catalog.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: pulumi-launchdarkly
+  description: Pulumi Provider for LaunchDarkly
+tags:
+- python
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/team-developer-experience
+  system: prima.it


### PR DESCRIPTION
This PR adds a Backstage Component entity definition.

Generated by the `add-component-to-catalog` software template.
