### PR TITLE
Migrate legacy LaunchDarkly state so it is readable by the v3 provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PULUMI_MISSING_DOCS_ERROR := true
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified
-PROVIDER_VERSION ?= 0.1.1
+PROVIDER_VERSION ?= 0.1.2
 
 # Check version doesn't start with a "v" - this is a common mistake
 ifeq ($(shell echo $(PROVIDER_VERSION) | cut -c1),v)

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -233,21 +233,20 @@ func Provider() tfbridge.ProviderInfo {
 	// read by this v3 (plugin-framework) based provider. See the comment on
 	// bumpStateSchemaVersion for the rationale.
 	//
-	// Every resource prima-pulumi creates whose upstream schema version is > 0
-	// carries Terraform state upgraders that cannot consume the object-shaped
-	// state persisted by the Pulumi bridge, so each needs a PreStateUpgradeHook.
-	// launchdarkly_feature_flag additionally needs custom_properties converted
-	// from the old list-of-blocks shape to the new map shape.
-	if r, ok := prov.Resources["launchdarkly_feature_flag"]; ok {
-		r.PreStateUpgradeHook = migrateFeatureFlagState
+	// Resources whose old state already has the current Pulumi shape only need a
+	// schema-version bump; the remaining hooks also migrate renamed fields.
+	stateMigrations := map[string]tfbridge.PreStateUpgradeHook{
+		"launchdarkly_access_token":             migrateAccessTokenState,
+		"launchdarkly_custom_role":              migrateCustomRoleState,
+		"launchdarkly_feature_flag":             migrateFeatureFlagState,
+		"launchdarkly_feature_flag_environment": bumpStateSchemaVersion,
+		"launchdarkly_metric":                   migrateMetricState,
+		"launchdarkly_project":                  migrateProjectState,
+		"launchdarkly_segment":                  bumpStateSchemaVersion,
 	}
-	for _, tfName := range []string{
-		"launchdarkly_feature_flag_environment",
-		"launchdarkly_segment",
-		"launchdarkly_metric",
-	} {
+	for tfName, hook := range stateMigrations {
 		if r, ok := prov.Resources[tfName]; ok {
-			r.PreStateUpgradeHook = bumpStateSchemaVersion
+			r.PreStateUpgradeHook = hook
 		}
 	}
 
@@ -268,11 +267,9 @@ func Provider() tfbridge.ProviderInfo {
 //
 //	AttributeName("fallthrough"): invalid JSON, expected "[", got "{"
 //
-// Because the persisted Pulumi state already matches the current schema shape,
-// we record it at the current schema version and skip the upgraders. Fields
-// with a genuine type change (e.g. custom_properties on launchdarkly_feature_flag,
-// which became a map) fail earlier during encoding and are handled by a
-// dedicated hook instead.
+// This is sufficient only where legacy Pulumi state already matches the
+// current Pulumi schema. Resources with renamed or re-keyed fields use a
+// resource-specific hook below before their schema version is advanced.
 func bumpStateSchemaVersion(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
 	if args.PriorStateSchemaVersion >= args.ResourceSchemaVersion {
 		return args.PriorStateSchemaVersion, args.PriorState, nil
@@ -283,71 +280,190 @@ func bumpStateSchemaVersion(args tfbridge.PreStateUpgradeHookArgs) (int64, resou
 // migrateFeatureFlagState upgrades Pulumi state written by pulumi-launchdarkly
 // <= 0.0.x for launchdarkly_feature_flag.
 //
-// In addition to the version bump performed by bumpStateSchemaVersion, this
-// resource has one field whose Pulumi representation genuinely changed shape:
-// custom_properties went from a set/list of {key, name, value} blocks to a map
-// keyed by the property key, with elements {name, values, key}. Old state
-// stores the list shape, which the bridge cannot encode against the new map
-// schema and fails with:
-//
-//	objectEncoder failed on property "custom_properties": Expected an Object PropertyValue, found []
-//
-// We convert custom_properties to the new map shape (the old plural
-// client_side_availabilities key is simply dropped and reconciled on the next
-// diff) and then record the current schema version to skip the upstream
-// upgraders, exactly as bumpStateSchemaVersion does.
+// The old Pulumi schema represented client-side availability as the plural
+// clientSideAvailabilities array and customProperties as an array of objects.
+// v3 uses a single clientSideAvailability object and a map keyed by property
+// key. includeInSnippet was replaced by client-side availability.
 func migrateFeatureFlagState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
-	// Only migrate state written before the current schema version.
+	return migrateLegacyState(args, func(state resource.PropertyMap) {
+		moveFirstArrayElement(state, "clientSideAvailabilities", "clientSideAvailability")
+		if propertyIsUnset(state, "clientSideAvailability") {
+			if includeInSnippet, ok := state["includeInSnippet"]; ok {
+				state["clientSideAvailability"] = resource.NewObjectProperty(resource.PropertyMap{
+					"usingEnvironmentId": includeInSnippet,
+					"usingMobileKey":     resource.NewBoolProperty(false),
+				})
+			}
+		}
+		delete(state, "includeInSnippet")
+		convertCustomPropertiesToMap(state)
+	})
+}
+
+// migrateMetricState renames randomizationUnits and removes the obsolete
+// isActive field from metric state.
+func migrateMetricState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
+	return migrateLegacyState(args, func(state resource.PropertyMap) {
+		moveProperty(state, "randomizationUnits", "analysisUnits")
+		delete(state, "isActive")
+	})
+}
+
+// migrateProjectState converts the legacy environment array to a map keyed by
+// environment key and applies the v2 includeInSnippet compatibility mapping.
+func migrateProjectState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
+	return migrateLegacyState(args, func(state resource.PropertyMap) {
+		moveFirstArrayElement(state, "defaultClientSideAvailabilities", "defaultClientSideAvailability")
+		if propertyIsUnset(state, "defaultClientSideAvailability") {
+			if includeInSnippet, ok := state["includeInSnippet"]; ok {
+				state["defaultClientSideAvailability"] = resource.NewObjectProperty(resource.PropertyMap{
+					"usingEnvironmentId": includeInSnippet,
+					"usingMobileKey":     resource.NewBoolProperty(true),
+				})
+			}
+		}
+		delete(state, "includeInSnippet")
+		convertArrayToMap(state, "environments", "key", convertProjectEnvironment)
+	})
+}
+
+// migrateAccessTokenState moves the removed policyStatements field to
+// inlineRoles and discards the obsolete expire field.
+func migrateAccessTokenState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
+	return migrateLegacyState(args, func(state resource.PropertyMap) {
+		moveProperty(state, "policyStatements", "inlineRoles")
+		delete(state, "expire")
+	})
+}
+
+// migrateCustomRoleState preserves the legacy policies value under the v3
+// policyStatements field.
+func migrateCustomRoleState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
+	return migrateLegacyState(args, func(state resource.PropertyMap) {
+		moveProperty(state, "policies", "policyStatements")
+	})
+}
+
+func migrateLegacyState(
+	args tfbridge.PreStateUpgradeHookArgs,
+	transform func(resource.PropertyMap),
+) (int64, resource.PropertyMap, error) {
 	if args.PriorStateSchemaVersion >= args.ResourceSchemaVersion {
 		return args.PriorStateSchemaVersion, args.PriorState, nil
 	}
 
 	state := args.PriorState
-	if cp, ok := state["customProperties"]; ok && cp.IsArray() {
-		entries := cp.ArrayValue()
-		if len(entries) == 0 {
-			// Empty in old state means "unset"; the new map schema treats an
-			// absent value the same way, avoiding a spurious empty-map diff.
-			delete(state, "customProperties")
-		} else {
-			state["customProperties"] = convertCustomPropertiesToMap(entries)
-		}
-	}
-
+	transform(state)
 	return args.ResourceSchemaVersion, state, nil
 }
 
-// convertCustomPropertiesToMap converts the old list-of-blocks representation of
-// custom_properties into the new map representation keyed by the property key.
-func convertCustomPropertiesToMap(entries []resource.PropertyValue) resource.PropertyValue {
-	properties := resource.PropertyMap{}
-	for _, entry := range entries {
-		if !entry.IsObject() {
-			continue
-		}
-		obj := entry.ObjectValue()
-
-		key := ""
-		if k, ok := obj["key"]; ok && k.IsString() {
-			key = k.StringValue()
-		}
-
-		element := resource.PropertyMap{}
-		if name, ok := obj["name"]; ok {
-			element["name"] = name
-		}
-		// The old element field "value" (list of strings) is named "values" in
-		// the new schema.
-		if values, ok := obj["value"]; ok {
-			element["values"] = values
-		} else if values, ok := obj["values"]; ok {
-			element["values"] = values
-		}
-		if key != "" {
-			element["key"] = resource.NewStringProperty(key)
-		}
-
-		properties[resource.PropertyKey(key)] = resource.NewObjectProperty(element)
+// moveProperty transfers a legacy field only when the v3 field is absent,
+// null, or an empty list. A populated v3 field remains authoritative.
+func moveProperty(state resource.PropertyMap, from, to resource.PropertyKey) {
+	if !propertyIsUnset(state, to) {
+		delete(state, from)
+		return
 	}
-	return resource.NewObjectProperty(properties)
+	if value, exists := state[from]; exists {
+		state[to] = value
+		delete(state, from)
+	}
+}
+
+// flattenFirstArrayElement converts a v2 single nested block to its v3 object
+// representation. Empty blocks are treated as unset.
+func flattenFirstArrayElement(state resource.PropertyMap, key resource.PropertyKey) {
+	value, exists := state[key]
+	if !exists || !value.IsArray() {
+		return
+	}
+	entries := value.ArrayValue()
+	if len(entries) == 0 {
+		delete(state, key)
+		return
+	}
+	state[key] = entries[0]
+}
+
+// moveFirstArrayElement transfers a legacy singleton array to its v3 object
+// field without overwriting a populated v3 value.
+func moveFirstArrayElement(state resource.PropertyMap, from, to resource.PropertyKey) {
+	if !propertyIsUnset(state, to) {
+		delete(state, from)
+		return
+	}
+	value, exists := state[from]
+	if !exists {
+		return
+	}
+	if value.IsArray() {
+		entries := value.ArrayValue()
+		if len(entries) > 0 {
+			state[to] = entries[0]
+		}
+	} else {
+		state[to] = value
+	}
+	delete(state, from)
+}
+
+func propertyIsUnset(state resource.PropertyMap, key resource.PropertyKey) bool {
+	value, exists := state[key]
+	return !exists || value.IsNull() || (value.IsArray() && len(value.ArrayValue()) == 0)
+}
+
+// convertArrayToMap re-keys a legacy array of objects into a v3 object/map
+// using an element field as the map key. The optional converter handles
+// element-level shape changes.
+func convertArrayToMap(
+	state resource.PropertyMap,
+	key, mapKey resource.PropertyKey,
+	convert func(resource.PropertyMap) resource.PropertyMap,
+) {
+	if cp, ok := state[key]; ok && cp.IsArray() {
+		entries := cp.ArrayValue()
+		properties := resource.PropertyMap{}
+		for _, entry := range entries {
+			if !entry.IsObject() {
+				continue
+			}
+			obj := entry.ObjectValue()
+			entryKey, ok := obj[mapKey]
+			if !ok || !entryKey.IsString() || entryKey.StringValue() == "" {
+				continue
+			}
+			if convert != nil {
+				obj = convert(obj)
+			}
+			properties[resource.PropertyKey(entryKey.StringValue())] = resource.NewObjectProperty(obj)
+		}
+		if len(properties) == 0 {
+			delete(state, key)
+			return
+		}
+		state[key] = resource.NewObjectProperty(properties)
+	}
+}
+
+// convertCustomPropertiesToMap converts feature flag customProperties from the
+// v2 array form to the v3 map form keyed by property key.
+func convertCustomPropertiesToMap(state resource.PropertyMap) {
+	convertArrayToMap(state, "customProperties", "key", convertCustomProperty)
+}
+
+// convertCustomProperty accepts the upstream Terraform v2 spelling (value) as
+// well as the Pulumi v2 spelling (values), which is already the v3 field name.
+func convertCustomProperty(obj resource.PropertyMap) resource.PropertyMap {
+	if values, ok := obj["value"]; ok {
+		obj["values"] = values
+		delete(obj, "value")
+	}
+	return obj
+}
+
+// convertProjectEnvironment flattens the nested v2 approvalSettings block
+// while its containing environment is re-keyed into the v3 map.
+func convertProjectEnvironment(obj resource.PropertyMap) resource.PropertyMap {
+	flattenFirstArrayElement(obj, "approvalSettings")
+	return obj
 }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -15,6 +15,8 @@
 package launchdarkly
 
 import (
+	"fmt"
+	"log"
 	"path"
 
 	// Allow embedding bridge-metadata.json in the provider.
@@ -234,15 +236,18 @@ func Provider() tfbridge.ProviderInfo {
 	// bumpStateSchemaVersion for the rationale.
 	//
 	// Resources whose old state already has the current Pulumi shape only need a
-	// schema-version bump; the remaining hooks also migrate renamed fields.
+	// schema-version bump; the remaining hooks also migrate renamed fields. Every
+	// hook additionally drops an unrecoverable raw-state delta (see
+	// dropStaleRawStateDelta), which also affects state written by intermediate
+	// v3 releases even when its schema version is already current.
 	stateMigrations := map[string]tfbridge.PreStateUpgradeHook{
 		"launchdarkly_access_token":             migrateAccessTokenState,
 		"launchdarkly_custom_role":              migrateCustomRoleState,
 		"launchdarkly_feature_flag":             migrateFeatureFlagState,
-		"launchdarkly_feature_flag_environment": bumpStateSchemaVersion,
+		"launchdarkly_feature_flag_environment": bumpStateSchemaVersion("feature_flag_environment"),
 		"launchdarkly_metric":                   migrateMetricState,
 		"launchdarkly_project":                  migrateProjectState,
-		"launchdarkly_segment":                  bumpStateSchemaVersion,
+		"launchdarkly_segment":                  bumpStateSchemaVersion("segment"),
 	}
 	for tfName, hook := range stateMigrations {
 		if r, ok := prov.Resources[tfName]; ok {
@@ -270,11 +275,53 @@ func Provider() tfbridge.ProviderInfo {
 // This is sufficient only where legacy Pulumi state already matches the
 // current Pulumi schema. Resources with renamed or re-keyed fields use a
 // resource-specific hook below before their schema version is advanced.
-func bumpStateSchemaVersion(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
-	if args.PriorStateSchemaVersion >= args.ResourceSchemaVersion {
-		return args.PriorStateSchemaVersion, args.PriorState, nil
+//
+// bumpStateSchemaVersion is a factory: it captures the resource name (used only
+// for logging) and returns the actual PreStateUpgradeHook.
+func bumpStateSchemaVersion(resourceName string) tfbridge.PreStateUpgradeHook {
+	return func(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
+		return migrateLegacyState(resourceName, args, nil)
 	}
-	return args.ResourceSchemaVersion, args.PriorState, nil
+}
+
+// rawStateDeltaKey is the bridge-reserved state key
+// (github.com/pulumi/pulumi-terraform-bridge/v3/pkg/reservedkeys.RawStateDelta)
+// under which the bridge records the delta between the Pulumi property map and
+// the Terraform raw state, so the latter can be reconstructed as-is at read time.
+//
+// A delta recorded by an older provider cannot be recovered once the Pulumi
+// projection changes: the v2 -> v3 upgrade flipped maxItemsOne on
+// custom_properties, fallthrough and defaults, so the stored delta no longer
+// applies to the current property map and `pulumi preview` aborts with:
+//
+//	[pf/tfbridge] Failed to recover raw state for Plugin Framework
+//
+// Dropping the key during state upgrade makes the bridge fall back to legacy
+// parsing instead of crashing; the provider re-inserts a correct delta on the
+// next write. This is done unconditionally (even when the schema version is
+// already current) because state written by an intermediate v3 release carries
+// the current schema version yet still holds an unrecoverable delta.
+const rawStateDeltaKey resource.PropertyKey = "__pulumi_raw_state_delta"
+
+// dropStaleRawStateDelta removes a raw-state delta the current bridge cannot
+// recover after the v2 -> v3 Pulumi shape changes and reports whether one was
+// present.
+func dropStaleRawStateDelta(state resource.PropertyMap) bool {
+	if _, present := state[rawStateDeltaKey]; !present {
+		return false
+	}
+	delete(state, rawStateDeltaKey)
+	return true
+}
+
+// logStateUpgrade emits a state-upgrade message through the standard logger,
+// which the Pulumi Terraform bridge redirects to the engine's diagnostic sink
+// (see pkg/pf/tfbridge/logging.go). Lines are surfaced to the user when the
+// provider runs with TF_LOG set: TF_LOG=INFO shows every step, TF_LOG=WARN shows
+// only the notable raw-state-delta drops.
+func logStateUpgrade(resourceName, level, format string, args ...any) {
+	log.Printf("[%s] pulumi-launchdarkly state upgrade (launchdarkly_%s): %s",
+		level, resourceName, fmt.Sprintf(format, args...))
 }
 
 // migrateFeatureFlagState upgrades Pulumi state written by pulumi-launchdarkly
@@ -285,7 +332,7 @@ func bumpStateSchemaVersion(args tfbridge.PreStateUpgradeHookArgs) (int64, resou
 // v3 uses a single clientSideAvailability object and a map keyed by property
 // key. includeInSnippet was replaced by client-side availability.
 func migrateFeatureFlagState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
-	return migrateLegacyState(args, func(state resource.PropertyMap) {
+	return migrateLegacyState("feature_flag", args, func(state resource.PropertyMap) {
 		moveFirstArrayElement(state, "clientSideAvailabilities", "clientSideAvailability")
 		if propertyIsUnset(state, "clientSideAvailability") {
 			if includeInSnippet, ok := state["includeInSnippet"]; ok {
@@ -303,7 +350,7 @@ func migrateFeatureFlagState(args tfbridge.PreStateUpgradeHookArgs) (int64, reso
 // migrateMetricState renames randomizationUnits and removes the obsolete
 // isActive field from metric state.
 func migrateMetricState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
-	return migrateLegacyState(args, func(state resource.PropertyMap) {
+	return migrateLegacyState("metric", args, func(state resource.PropertyMap) {
 		moveProperty(state, "randomizationUnits", "analysisUnits")
 		delete(state, "isActive")
 	})
@@ -312,7 +359,7 @@ func migrateMetricState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.
 // migrateProjectState converts the legacy environment array to a map keyed by
 // environment key and applies the v2 includeInSnippet compatibility mapping.
 func migrateProjectState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
-	return migrateLegacyState(args, func(state resource.PropertyMap) {
+	return migrateLegacyState("project", args, func(state resource.PropertyMap) {
 		moveFirstArrayElement(state, "defaultClientSideAvailabilities", "defaultClientSideAvailability")
 		if propertyIsUnset(state, "defaultClientSideAvailability") {
 			if includeInSnippet, ok := state["includeInSnippet"]; ok {
@@ -330,7 +377,7 @@ func migrateProjectState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource
 // migrateAccessTokenState moves the removed policyStatements field to
 // inlineRoles and discards the obsolete expire field.
 func migrateAccessTokenState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
-	return migrateLegacyState(args, func(state resource.PropertyMap) {
+	return migrateLegacyState("access_token", args, func(state resource.PropertyMap) {
 		moveProperty(state, "policyStatements", "inlineRoles")
 		delete(state, "expire")
 	})
@@ -339,21 +386,33 @@ func migrateAccessTokenState(args tfbridge.PreStateUpgradeHookArgs) (int64, reso
 // migrateCustomRoleState preserves the legacy policies value under the v3
 // policyStatements field.
 func migrateCustomRoleState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
-	return migrateLegacyState(args, func(state resource.PropertyMap) {
+	return migrateLegacyState("custom_role", args, func(state resource.PropertyMap) {
 		moveProperty(state, "policies", "policyStatements")
 	})
 }
 
 func migrateLegacyState(
+	resourceName string,
 	args tfbridge.PreStateUpgradeHookArgs,
 	transform func(resource.PropertyMap),
 ) (int64, resource.PropertyMap, error) {
+	state := args.PriorState
+	if dropStaleRawStateDelta(state) {
+		logStateUpgrade(resourceName, "WARN",
+			"dropped unrecoverable raw-state delta (%q); the resource will be re-read via "+
+				"legacy state parsing and a fresh delta re-recorded on the next update",
+			rawStateDeltaKey)
+	}
 	if args.PriorStateSchemaVersion >= args.ResourceSchemaVersion {
-		return args.PriorStateSchemaVersion, args.PriorState, nil
+		return args.PriorStateSchemaVersion, state, nil
 	}
 
-	state := args.PriorState
-	transform(state)
+	if transform != nil {
+		transform(state)
+	}
+	logStateUpgrade(resourceName, "INFO",
+		"migrated legacy Pulumi state from schema version %d to %d",
+		args.PriorStateSchemaVersion, args.ResourceSchemaVersion)
 	return args.ResourceSchemaVersion, state, nil
 }
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
 	"github.com/primait/pulumi-launchdarkly/provider/pkg/version"
 )
@@ -227,5 +228,126 @@ func Provider() tfbridge.ProviderInfo {
 	prov.MustApplyAutoAliases()
 	prov.SetAutonaming(255, "-")
 
+	// Migrate Pulumi state written by pulumi-launchdarkly <= 0.0.x
+	// (terraform-provider-launchdarkly v2, terraform-plugin-sdk/v2) so it can be
+	// read by this v3 (plugin-framework) based provider. See the comment on
+	// bumpStateSchemaVersion for the rationale.
+	//
+	// Every resource prima-pulumi creates whose upstream schema version is > 0
+	// carries Terraform state upgraders that cannot consume the object-shaped
+	// state persisted by the Pulumi bridge, so each needs a PreStateUpgradeHook.
+	// launchdarkly_feature_flag additionally needs custom_properties converted
+	// from the old list-of-blocks shape to the new map shape.
+	if r, ok := prov.Resources["launchdarkly_feature_flag"]; ok {
+		r.PreStateUpgradeHook = migrateFeatureFlagState
+	}
+	for _, tfName := range []string{
+		"launchdarkly_feature_flag_environment",
+		"launchdarkly_segment",
+		"launchdarkly_metric",
+	} {
+		if r, ok := prov.Resources[tfName]; ok {
+			r.PreStateUpgradeHook = bumpStateSchemaVersion
+		}
+	}
+
 	return prov
+}
+
+// bumpStateSchemaVersion upgrades Pulumi state written by pulumi-launchdarkly
+// <= 0.0.x (terraform-provider-launchdarkly v2, terraform-plugin-sdk/v2) so it
+// can be read by the v3 (plugin-framework) based provider without invoking the
+// upstream Terraform state upgraders.
+//
+// The upstream v0/v1 upgraders operate on the raw terraform-plugin-sdk/v2 state
+// shape, in which single-nested blocks (MaxItems: 1, e.g. fallthrough) are
+// encoded as single-element lists. The Pulumi bridge has always flattened those
+// MaxItemsOne blocks into objects, so the state it persisted is already in the
+// object shape that the v3 plugin-framework schema expects. Feeding that
+// object-shaped state to the v0 upgrader fails with errors such as:
+//
+//	AttributeName("fallthrough"): invalid JSON, expected "[", got "{"
+//
+// Because the persisted Pulumi state already matches the current schema shape,
+// we record it at the current schema version and skip the upgraders. Fields
+// with a genuine type change (e.g. custom_properties on launchdarkly_feature_flag,
+// which became a map) fail earlier during encoding and are handled by a
+// dedicated hook instead.
+func bumpStateSchemaVersion(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
+	if args.PriorStateSchemaVersion >= args.ResourceSchemaVersion {
+		return args.PriorStateSchemaVersion, args.PriorState, nil
+	}
+	return args.ResourceSchemaVersion, args.PriorState, nil
+}
+
+// migrateFeatureFlagState upgrades Pulumi state written by pulumi-launchdarkly
+// <= 0.0.x for launchdarkly_feature_flag.
+//
+// In addition to the version bump performed by bumpStateSchemaVersion, this
+// resource has one field whose Pulumi representation genuinely changed shape:
+// custom_properties went from a set/list of {key, name, value} blocks to a map
+// keyed by the property key, with elements {name, values, key}. Old state
+// stores the list shape, which the bridge cannot encode against the new map
+// schema and fails with:
+//
+//	objectEncoder failed on property "custom_properties": Expected an Object PropertyValue, found []
+//
+// We convert custom_properties to the new map shape (the old plural
+// client_side_availabilities key is simply dropped and reconciled on the next
+// diff) and then record the current schema version to skip the upstream
+// upgraders, exactly as bumpStateSchemaVersion does.
+func migrateFeatureFlagState(args tfbridge.PreStateUpgradeHookArgs) (int64, resource.PropertyMap, error) {
+	// Only migrate state written before the current schema version.
+	if args.PriorStateSchemaVersion >= args.ResourceSchemaVersion {
+		return args.PriorStateSchemaVersion, args.PriorState, nil
+	}
+
+	state := args.PriorState
+	if cp, ok := state["customProperties"]; ok && cp.IsArray() {
+		entries := cp.ArrayValue()
+		if len(entries) == 0 {
+			// Empty in old state means "unset"; the new map schema treats an
+			// absent value the same way, avoiding a spurious empty-map diff.
+			delete(state, "customProperties")
+		} else {
+			state["customProperties"] = convertCustomPropertiesToMap(entries)
+		}
+	}
+
+	return args.ResourceSchemaVersion, state, nil
+}
+
+// convertCustomPropertiesToMap converts the old list-of-blocks representation of
+// custom_properties into the new map representation keyed by the property key.
+func convertCustomPropertiesToMap(entries []resource.PropertyValue) resource.PropertyValue {
+	properties := resource.PropertyMap{}
+	for _, entry := range entries {
+		if !entry.IsObject() {
+			continue
+		}
+		obj := entry.ObjectValue()
+
+		key := ""
+		if k, ok := obj["key"]; ok && k.IsString() {
+			key = k.StringValue()
+		}
+
+		element := resource.PropertyMap{}
+		if name, ok := obj["name"]; ok {
+			element["name"] = name
+		}
+		// The old element field "value" (list of strings) is named "values" in
+		// the new schema.
+		if values, ok := obj["value"]; ok {
+			element["values"] = values
+		} else if values, ok := obj["values"]; ok {
+			element["values"] = values
+		}
+		if key != "" {
+			element["key"] = resource.NewStringProperty(key)
+		}
+
+		properties[resource.PropertyKey(key)] = resource.NewObjectProperty(element)
+	}
+	return resource.NewObjectProperty(properties)
 }

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -149,3 +149,75 @@ func legacyStateArgs(state resource.PropertyMap) tfbridge.PreStateUpgradeHookArg
 		ResourceSchemaVersion:   1,
 	}
 }
+
+// TestBumpStateSchemaVersionDropsRawStateDelta covers the core-infra case: state
+// written by an intermediate v3 release carries the current schema version yet an
+// unrecoverable raw-state delta. bumpStateSchemaVersion (used by
+// feature_flag_environment and segment) must still drop the delta.
+func TestBumpStateSchemaVersionDropsRawStateDelta(t *testing.T) {
+	t.Parallel()
+	state := resource.PropertyMap{
+		"offVariation":   resource.NewNumberProperty(1),
+		rawStateDeltaKey: resource.NewObjectProperty(resource.PropertyMap{}),
+	}
+	version, migrated, err := bumpStateSchemaVersion("feature_flag_environment")(tfbridge.PreStateUpgradeHookArgs{
+		PriorState:              state,
+		PriorStateSchemaVersion: 1,
+		ResourceSchemaVersion:   1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != 1 {
+		t.Fatalf("unexpected schema version: %d", version)
+	}
+	if _, exists := migrated[rawStateDeltaKey]; exists {
+		t.Fatal("raw state delta was not dropped")
+	}
+	if migrated["offVariation"].NumberValue() != 1 {
+		t.Fatalf("offVariation changed: %#v", migrated["offVariation"])
+	}
+}
+
+// TestMigrateFeatureFlagStateDropsRawStateDelta covers the same case for the
+// feature_flag hook, where the state is already in v3 shape (customProperties is
+// a map) but still holds an unrecoverable delta.
+func TestMigrateFeatureFlagStateDropsRawStateDelta(t *testing.T) {
+	t.Parallel()
+	state := resource.PropertyMap{
+		"customProperties": resource.NewObjectProperty(resource.PropertyMap{}),
+		rawStateDeltaKey:   resource.NewObjectProperty(resource.PropertyMap{}),
+	}
+	_, migrated, err := migrateFeatureFlagState(tfbridge.PreStateUpgradeHookArgs{
+		PriorState:              state,
+		PriorStateSchemaVersion: 2,
+		ResourceSchemaVersion:   2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := migrated[rawStateDeltaKey]; exists {
+		t.Fatal("raw state delta was not dropped")
+	}
+}
+
+// TestMigrateLegacyStateDropsRawStateDeltaOnOldState ensures the delta is also
+// dropped on genuinely old (pre-v3) state alongside the field migration.
+func TestMigrateLegacyStateDropsRawStateDeltaOnOldState(t *testing.T) {
+	t.Parallel()
+	state := resource.PropertyMap{
+		"isActive":           resource.NewBoolProperty(true),
+		"randomizationUnits": resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("user")}),
+		rawStateDeltaKey:     resource.NewObjectProperty(resource.PropertyMap{}),
+	}
+	_, migrated, err := migrateMetricState(legacyStateArgs(state))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := migrated[rawStateDeltaKey]; exists {
+		t.Fatal("raw state delta was not dropped")
+	}
+	if migrated["analysisUnits"].ArrayValue()[0].StringValue() != "user" {
+		t.Fatalf("unexpected analysisUnits: %#v", migrated["analysisUnits"])
+	}
+}

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -1,0 +1,151 @@
+package launchdarkly
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestMigrateFeatureFlagState(t *testing.T) {
+	t.Parallel()
+	state := resource.PropertyMap{
+		"includeInSnippet": resource.NewBoolProperty(true),
+		"customProperties": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewObjectProperty(resource.PropertyMap{
+				"key":    resource.NewStringProperty("owner"),
+				"name":   resource.NewStringProperty("Owner"),
+				"values": resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("platform")}),
+			}),
+		}),
+	}
+
+	_, migrated, err := migrateFeatureFlagState(legacyStateArgs(state))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := migrated["includeInSnippet"]; exists {
+		t.Fatal("includeInSnippet was not removed")
+	}
+	availability := migrated["clientSideAvailability"].ObjectValue()
+	if !availability["usingEnvironmentId"].BoolValue() || availability["usingMobileKey"].BoolValue() {
+		t.Fatalf("unexpected clientSideAvailability: %#v", availability)
+	}
+	properties := migrated["customProperties"].ObjectValue()
+	owner := properties["owner"].ObjectValue()
+	if owner["key"].StringValue() != "owner" || owner["values"].ArrayValue()[0].StringValue() != "platform" {
+		t.Fatalf("unexpected customProperties: %#v", properties)
+	}
+}
+
+func TestMigrateMetricState(t *testing.T) {
+	t.Parallel()
+	state := resource.PropertyMap{
+		"isActive":           resource.NewBoolProperty(true),
+		"randomizationUnits": resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("user")}),
+	}
+
+	_, migrated, err := migrateMetricState(legacyStateArgs(state))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := migrated["isActive"]; exists {
+		t.Fatal("isActive was not removed")
+	}
+	if migrated["analysisUnits"].ArrayValue()[0].StringValue() != "user" {
+		t.Fatalf("unexpected analysisUnits: %#v", migrated["analysisUnits"])
+	}
+}
+
+func TestMigrateProjectState(t *testing.T) {
+	t.Parallel()
+	state := resource.PropertyMap{
+		"includeInSnippet": resource.NewBoolProperty(false),
+		"environments": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewObjectProperty(resource.PropertyMap{
+				"key": resource.NewStringProperty("production"),
+				"approvalSettings": resource.NewArrayProperty([]resource.PropertyValue{
+					resource.NewObjectProperty(resource.PropertyMap{
+						"required": resource.NewBoolProperty(true),
+					}),
+				}),
+			}),
+		}),
+	}
+
+	_, migrated, err := migrateProjectState(legacyStateArgs(state))
+	if err != nil {
+		t.Fatal(err)
+	}
+	availability := migrated["defaultClientSideAvailability"].ObjectValue()
+	if availability["usingEnvironmentId"].BoolValue() || !availability["usingMobileKey"].BoolValue() {
+		t.Fatalf("unexpected defaultClientSideAvailability: %#v", availability)
+	}
+	environments := migrated["environments"].ObjectValue()
+	production := environments["production"].ObjectValue()
+	if !production["approvalSettings"].ObjectValue()["required"].BoolValue() {
+		t.Fatalf("unexpected environments: %#v", environments)
+	}
+}
+
+func TestMigrateAccessTokenState(t *testing.T) {
+	t.Parallel()
+	tokenState := resource.PropertyMap{
+		"expire": resource.NewNumberProperty(123),
+		"policyStatements": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewObjectProperty(resource.PropertyMap{"effect": resource.NewStringProperty("allow")}),
+		}),
+	}
+	_, migratedToken, err := migrateAccessTokenState(legacyStateArgs(tokenState))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := migratedToken["expire"]; exists {
+		t.Fatal("expire was not removed")
+	}
+	if migratedToken["inlineRoles"].ArrayValue()[0].ObjectValue()["effect"].StringValue() != "allow" {
+		t.Fatalf("unexpected inlineRoles: %#v", migratedToken["inlineRoles"])
+	}
+}
+
+func TestMigrateCustomRoleState(t *testing.T) {
+	t.Parallel()
+	customRoleState := resource.PropertyMap{
+		"policies": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewObjectProperty(resource.PropertyMap{"effect": resource.NewStringProperty("allow")}),
+		}),
+	}
+	_, migratedCustomRole, err := migrateCustomRoleState(legacyStateArgs(customRoleState))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if migratedCustomRole["policyStatements"].ArrayValue()[0].ObjectValue()["effect"].StringValue() != "allow" {
+		t.Fatalf("unexpected policyStatements: %#v", migratedCustomRole["policyStatements"])
+	}
+}
+
+func TestStateMigrationDoesNotChangeCurrentState(t *testing.T) {
+	t.Parallel()
+	state := resource.PropertyMap{"analysisUnits": resource.NewArrayProperty(nil)}
+	args := tfbridge.PreStateUpgradeHookArgs{
+		PriorState:              state,
+		PriorStateSchemaVersion: 2,
+		ResourceSchemaVersion:   2,
+	}
+
+	version, migrated, err := migrateMetricState(args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != 2 || len(migrated) != 1 {
+		t.Fatalf("current state changed: version=%d state=%#v", version, migrated)
+	}
+}
+
+func legacyStateArgs(state resource.PropertyMap) tfbridge.PreStateUpgradeHookArgs {
+	return tfbridge.PreStateUpgradeHookArgs{
+		PriorState:              state,
+		PriorStateSchemaVersion: 0,
+		ResourceSchemaVersion:   1,
+	}
+}

--- a/sdk/dotnet/Pulumi.Launchdarkly.csproj
+++ b/sdk/dotnet/Pulumi.Launchdarkly.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://www.pulumi.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/primait/pulumi-launchdarkly</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
 
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,6 +1,6 @@
 {
   "resource": true,
   "name": "launchdarkly",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "server": "github://api.github.com/primait/pulumi-launchdarkly"
 }

--- a/sdk/go/launchdarkly/internal/pulumiUtilities.go
+++ b/sdk/go/launchdarkly/internal/pulumiUtilities.go
@@ -165,7 +165,7 @@ func callPlainInner(
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
 	defaults = append(defaults, pulumi.PluginDownloadURL("github://api.github.com/primait/pulumi-launchdarkly"))
-	version := semver.MustParse("0.1.1")
+	version := semver.MustParse("0.1.2")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}
@@ -176,7 +176,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
 	defaults = append(defaults, pulumi.PluginDownloadURL("github://api.github.com/primait/pulumi-launchdarkly"))
-	version := semver.MustParse("0.1.1")
+	version := semver.MustParse("0.1.2")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}

--- a/sdk/go/launchdarkly/pulumi-plugin.json
+++ b/sdk/go/launchdarkly/pulumi-plugin.json
@@ -1,6 +1,6 @@
 {
   "resource": true,
   "name": "launchdarkly",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "server": "github://api.github.com/primait/pulumi-launchdarkly"
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/launchdarkly",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "A Pulumi package for creating and managing launchdarkly cloud resources.",
     "keywords": [
         "launchdarkly",
@@ -22,7 +22,7 @@
     "pulumi": {
         "resource": true,
         "name": "launchdarkly",
-        "version": "0.1.1",
+        "version": "0.1.2",
         "server": "github://api.github.com/primait/pulumi-launchdarkly"
     }
 }

--- a/sdk/python/pulumi_launchdarkly/pulumi-plugin.json
+++ b/sdk/python/pulumi_launchdarkly/pulumi-plugin.json
@@ -1,6 +1,6 @@
 {
   "resource": true,
   "name": "launchdarkly",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "server": "github://api.github.com/primait/pulumi-launchdarkly"
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@
   keywords = ["launchdarkly", "category/cloud"]
   readme = "README.md"
   requires-python = ">=3.9"
-  version = "0.1.1"
+  version = "0.1.2"
   [project.license]
     text = "Apache-2.0"
   [project.urls]


### PR DESCRIPTION
`pulumi-launchdarkly <= 0.0.x` was built on `terraform-provider-launchdarkly v2` (`terraform-plugin-sdk/v2`). The v3 provider bumped several resource schema versions and ships Terraform state upgraders that expect the raw SDKv2 state shape, where `MaxItems: 1` blocks are single-element lists. The Pulumi bridge has always flattened those blocks into objects, so state written by the old provider cannot be consumed by the v0 upgraders and preview fails, e.g. for `launchdarkly_feature_flag_environment`:

 ```
 AttributeName("fallthrough"): invalid JSON, expected "[", got "{":
  Unable to Read Previously Saved State for UpgradeResourceState
```

`launchdarkly_feature_flag` additionally changed `custom_properties` from a set/list of {key, name, value} blocks into a map keyed by the property key, which fails even earlier during encoding:

```
  objectEncoder failed on property "custom_properties":
  Expected an Object PropertyValue, found []
```

This PR add `PreStateUpgradeHooks` that record the persisted (already object-shaped) Pulumi state at the current schema version, skipping the upstream upgraders:

  * `bumpStateSchemaVersion`  - generic version bump, wired for `launchdarkly_feature_flag_environment`, `launchdarkly_segment` and `launchdarkly_metric` (the remaining resources prima-pulumi creates that carry schema version > 0).
  * `migrateFeatureFlagState` - additionally converts `custom_properties` to the new map shape for `launchdarkly_feature_flag`.
 
Also, state-upgrade hooks now strip the unrecoverable raw-state delta. When the delta key is absent, the bridge skips the failing `recoverRawState` and falls back to legacy parsing instead of crashing. The provider re-inserts a correct delta on the next write, so it self-heals.

The hooks are runtime-only (no schema change) and no-op for state already at the current version, so freshly created v3 resources are unaffected.

Thanks @brokenpip3 for the pairing session ❤️ 